### PR TITLE
Added CentOS/RH dependencies for python crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This pack consists of a sample JIRA sensor and a JIRA action.
 ## Installation
 
 You will need to have `gcc` installed on your system. For Ubuntu systems, run `sudo apt-get install gcc`. For Redhat/CentOS
-systems, run `sudo yum install gcc libffi-devel python-devel openssl-devel`. To build the python cryptography dependency (part of the following `st2 pack install` command, 2GB of RAM is recommended. In some cases adding a swap file may eliminate strange gcc compiler errors.
+systems, run `sudo yum install gcc libffi-devel python-devel openssl-devel`. To build the python cryptography dependency (part of the following `st2 pack install` command) 2GB of RAM is recommended. In some cases adding a swap file may eliminate strange gcc compiler errors.
 
 Then install this pack with: `st2 pack install jira`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This pack consists of a sample JIRA sensor and a JIRA action.
 ## Installation
 
 You will need to have `gcc` installed on your system. For Ubuntu systems, run `sudo apt-get install gcc`. For Redhat/CentOS
-systems, run `sudo yum install gcc libffi-devel python-devel openssl-devel`. To build the python cryptography dependency (part of the following "st2 pack install command" command, 2GB of RAM is recommended. In some cases adding a swap file may elimiate strange gcc compiler errors.
+systems, run `sudo yum install gcc libffi-devel python-devel openssl-devel`. To build the python cryptography dependency (part of the following `st2 pack install` command, 2GB of RAM is recommended. In some cases adding a swap file may eliminate strange gcc compiler errors.
 
 Then install this pack with: `st2 pack install jira`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This pack consists of a sample JIRA sensor and a JIRA action.
 ## Installation
 
 You will need to have `gcc` installed on your system. For Ubuntu systems, run `sudo apt-get install gcc`. For Redhat/CentOS
-systems, run `sudo yum install gcc`.
+systems, run `sudo yum install gcc libffi-devel python-devel openssl-devel`. To build the python cryptography dependency (part of the following "st2 pack install command" command, 2GB of RAM is recommended. In some cases adding a swap file may elimiate strange gcc compiler errors.
 
 Then install this pack with: `st2 pack install jira`
 


### PR DESCRIPTION
From https://cryptography.io/en/latest/installation/#building-cryptography-on-linux
sudo yum install gcc libffi-devel python-devel openssl-devel