### PR TITLE
Added verify option. Fixes #1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.1
+
+- Added 'verify' option to disable SSL certificate verification
+
 # 0.4.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ to `/opt/stackstorm/configs/jira.yaml` and edit as required.
 * ``poll_interval`` - Polling interval - default 30s
 * ``project`` - Key of the project which will be used as a default with some of the actions which
   don't require or allow you to specify a project (e.g. ``STORM``).
+* ``verify`` - Verify SSL certificates. Default True. Set to False to disable verification
 
 To get these OAuth credentials, take a look at OAuth section below.
 

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -19,7 +19,7 @@ class BaseJiraAction(Action):
     def _get_client(self):
         config = self.config
 
-        options = {'server': config['url']}
+        options = {'server': config['url'], 'verify': config['verify']}
 
         rsa_cert_file = config['rsa_cert_file']
         rsa_key_content = self._get_file_content(file_path=rsa_cert_file)

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -4,6 +4,10 @@
     type: "string"
     secret: false
     required: true
+  verify:
+    description: "Verify SSL certificate. Set to False to disable verification. Default True"
+    type: boolean
+    default: True
   rsa_cert_file:
     description: "Path to a private key file, e.g. /home/vagrant/jira.pem"
     type: "string"

--- a/jira.yaml.example
+++ b/jira.yaml.example
@@ -6,3 +6,4 @@
   consumer_key: ""
   poll_interval: 30
   project: "MY_PROJECT"
+  verify: True

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - issues
   - ticket management
   - project management
-version : 0.4.0
+version : 0.4.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Added option to disable SSL certificate verification. Default is True (i.e., validate certificates). Can set to `False` to disable verification. Useful for ppl running internal Jira instances, or those with MiTM proxies.

Fixes #1 