### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.5.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.4.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ To get these OAuth credentials, take a look at OAuth section below.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ### OAuth
 
 ### Disclaimer

--- a/actions/comment_issue.yaml
+++ b/actions/comment_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: comment_issue
-runner_type: run-python
+runner_type: python-script
 description: Comment on a JIRA issue / ticket.
 enabled: true
 entry_point: comment_issue.py

--- a/actions/create_issue.yaml
+++ b/actions/create_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: create_issue
-runner_type: run-python
+runner_type: python-script
 description: Create a new JIRA issue / ticket.
 enabled: true
 entry_point: create_issue.py

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_issue
-runner_type: run-python
+runner_type: python-script
 description: Retrieve information about a particular JIRA issue.
 enabled: true
 entry_point: get_issue.py

--- a/actions/transition_issue.yaml
+++ b/actions/transition_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: transition_issue
-runner_type: run-python
+runner_type: python-script
 description: Do a transition on a JIRA issue / ticket.
 enabled: true
 entry_point: transition_issue.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - issues
   - ticket management
   - project management
-version : 0.4.0
+version : 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.