### PR TITLE
Add a attach file to issue option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,22 @@
 # Change Log
 
-# 0.5.1
+## 0.6.0
+
+- Add new ``jira.get_issue_comments`` action
+- Add new ``jira.get_issue_attachments`` action
+- Add new ``include_comments`` and ``include_attachments`` parameter to
+  ``jira.get_issue`` action which allows users to retrieve comments and
+  attachments in a single call when retrieving issue details. For backward
+  compatibility reasons, both arguments default to ``False``.
+
+## 0.5.1
 
 - Added 'verify' option to disable SSL certificate verification
 
-# 0.5.0
+## 0.5.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
 
-# 0.4.0
+## 0.4.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/actions/attach_file_to_issue.py
+++ b/actions/attach_file_to_issue.py
@@ -8,22 +8,20 @@ __all__ = [
 class AttachFileToJiraIssueAction(BaseJiraAction):
 
     def run(self, issue_key, file_path, file_name=None):
-        with open(file_path) as attach_file:
-            if file_name == "":
-                file_name = None 
+        if not file_name:
+            file_name = None
 
+        with open(file_path, 'rb') as fp:
             attachment = self._client.add_attachment(
-                issue=issue_key, 
-                attachment=attach_file,
+                issue=issue_key,
+                attachment=fp,
                 filename=file_name)
-            
-            result = {
-                "issue": issue_key,
-                "filename": attachment.filename,
-                "size": attachment.size,
-                "created_at": attachment.created
-            }
 
-            return result
-            
-        raise Exception("Failed attaching file %s to issue %s." % (file_path, issue_key))
+        result = {
+            "issue": issue_key,
+            "filename": attachment.filename,
+            "size": attachment.size,
+            "created_at": attachment.created
+        }
+
+        return result

--- a/actions/attach_file_to_issue.py
+++ b/actions/attach_file_to_issue.py
@@ -1,0 +1,29 @@
+from lib.base import BaseJiraAction
+
+__all__ = [
+    'AttachFileToJiraIssueAction'
+]
+
+
+class AttachFileToJiraIssueAction(BaseJiraAction):
+
+    def run(self, issue_key, file_path, file_name=None):
+        with open(file_path) as attach_file:
+            if file_name == "":
+                file_name = None 
+
+            attachment = self._client.add_attachment(
+                issue=issue_key, 
+                attachment=attach_file,
+                filename=file_name)
+            
+            result = {
+                "issue": issue_key,
+                "filename": attachment.filename,
+                "size": attachment.size,
+                "created_at": attachment.created
+            }
+
+            return result
+            
+        raise Exception("Failed attaching file %s to issue %s." % (file_path, issue_key))

--- a/actions/attach_file_to_issue.yaml
+++ b/actions/attach_file_to_issue.yaml
@@ -1,0 +1,19 @@
+---
+name: attach_file_to_issue
+runner_type: python-script
+description: Attach a file to JIRA issue / ticket.
+enabled: true
+entry_point: attach_file_to_issue.py
+parameters:
+  file_path:
+    type: string
+    description: Path of the file to attach to issue.
+    required: true
+  file_name:
+    type: string
+    description: Optional file name for the attachment. If not provided, name of the file on disk is assumed.
+    required: false
+  issue_key:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -7,7 +7,8 @@ __all__ = [
 
 
 class GetJiraIssueAction(BaseJiraAction):
-    def run(self, issue_key):
+    def run(self, issue_key, include_comments=False, include_attachments=False):
         issue = self._client.issue(issue_key)
-        result = to_issue_dict(issue=issue)
+        result = to_issue_dict(issue=issue, include_comments=include_comments,
+                               include_attachments=include_attachments)
         return result

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -10,11 +10,12 @@ parameters:
     description: Issue key (e.g. PROJECT-1000).
     required: true
   include_comments:
-    type: string
+    type: boolean
     description: True to include issue comments.
     required: true
     default: false
   include_attachments:
-    type: string
+    type: boolean
     description: True to include issue attachments.
     required: true
+    default: false

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -9,3 +9,12 @@ parameters:
     type: string
     description: Issue key (e.g. PROJECT-1000).
     required: true
+  include_comments:
+    type: string
+    description: True to include issue comments.
+    required: true
+    default: false
+  include_attachments:
+    type: string
+    description: True to include issue attachments.
+    required: true

--- a/actions/get_issue_attachments.py
+++ b/actions/get_issue_attachments.py
@@ -1,0 +1,19 @@
+from lib.base import BaseJiraAction
+from lib.formatters import to_attachment_dict
+
+__all__ = [
+    'GetJiraIssueAttachmentsAction'
+]
+
+
+class GetJiraIssueAttachmentsAction(BaseJiraAction):
+    def run(self, issue_key):
+        issue = self._client.issue(issue_key)
+
+        result = []
+
+        for attachment in issue.fields.attachment:
+            item = to_attachment_dict(attachment)
+            result.append(item)
+
+        return result

--- a/actions/get_issue_attachments.yaml
+++ b/actions/get_issue_attachments.yaml
@@ -1,0 +1,11 @@
+---
+name: get_issue_attachments
+runner_type: python-script
+description: Retrieve attachments for a particular JIRA issue.
+enabled: true
+entry_point: get_issue_attachments.py
+parameters:
+  issue_key:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true

--- a/actions/get_issue_comments.py
+++ b/actions/get_issue_comments.py
@@ -1,0 +1,19 @@
+from lib.base import BaseJiraAction
+from lib.formatters import to_comment_dict
+
+__all__ = [
+    'GetJiraIssueCommentsAction'
+]
+
+
+class GetJiraIssueCommentsAction(BaseJiraAction):
+    def run(self, issue_key):
+        issue = self._client.issue(issue_key)
+
+        result = []
+
+        for comment in issue.fields.comment.comments:
+            item = to_comment_dict(comment)
+            result.append(item)
+
+        return result

--- a/actions/get_issue_comments.yaml
+++ b/actions/get_issue_comments.yaml
@@ -1,0 +1,11 @@
+---
+name: get_issue_comments
+runner_type: python-script
+description: Retrieve comments for a particular JIRA issue.
+enabled: true
+entry_point: get_issue_comments.py
+parameters:
+  issue_key:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -4,7 +4,7 @@ __all__ = [
 ]
 
 
-def to_issue_dict(issue):
+def to_issue_dict(issue, include_comments=False, include_attachments=False):
     """
     :rtype: ``dict``
     """
@@ -41,6 +41,20 @@ def to_issue_dict(issue):
         'updated_at': issue.fields.updated,
         'resolved_at': issue.fields.resolutiondate
     }
+
+    if include_comments:
+        result['comments'] = []
+        for comment in issue.fields.comment.comments:
+            item = to_comment_dict(comment)
+            result['comments'].append(item)
+
+    if include_attachments:
+        result['attachments'] = []
+
+        for attachment in issue.fields.attachment:
+            item = to_attachment_dict(attachment)
+            result['attachment'].append(item)
+
     return result
 
 

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -44,6 +44,7 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False):
 
     if include_comments:
         result['comments'] = []
+
         for comment in issue.fields.comment.comments:
             item = to_comment_dict(comment)
             result['comments'].append(item)
@@ -53,7 +54,7 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False):
 
         for attachment in issue.fields.attachment:
             item = to_attachment_dict(attachment)
-            result['attachment'].append(item)
+            result['attachments'].append(item)
 
     return result
 

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -53,3 +53,16 @@ def to_comment_dict(comment):
         'body': comment.body
     }
     return result
+
+
+def to_attachment_dict(attachment):
+    """
+    :rtype: ``dict``
+    """
+    result = {
+        'filename': attachment.created_at,
+        'size': attachment.size,
+        'created_at': attachment.created,
+        'content': attachment.content,
+    }
+    return result

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -60,7 +60,7 @@ def to_attachment_dict(attachment):
     :rtype: ``dict``
     """
     result = {
-        'filename': attachment.created_at,
+        'filename': attachment.filename,
         'size': attachment.size,
         'created_at': attachment.created,
         'content': attachment.content,

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.5.2
+version: 0.6.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run jira.attach_file_to_issue issue_key=BWC-6755 file_path=/tmp/ma_file             master ✭ ◼
..
id: 5a0dc567d9d7ed65eac4be49
status: succeeded
parameters:
  file_path: /tmp/ma_file
  issue_key: BWC-6755
result:
  exit_code: 0
  result:
    created_at: 2017-11-16T09:05:45.649-0800
    filename: ma_file
    issue: BWC-6755
    size: 66
  stderr: 'WARNING:root:/tmp/ma_file was not opened in ''rb'' mode, attaching file may fail.

    '
  stdout: ''
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯
```

Uploading a pcap file doesn't work reliably. I think the jira client is broken when it comes to binary file uploads. I'll debug that. 