### PR TITLE
Updated PyYAML to 4.2b4 for CVE-2017-18342

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.10.1
+
+- Updated PyYAML to 4.2b4 for CVE-2017-18342
+
 ## 0.10.0
 
 - Add new ``jira.assign_issues`` action

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jira==2.0.0
-pyyaml==3.13
+pyyaml==4.2b4
 cryptography==2.4.1
 pyjwt==1.6.4


### PR DESCRIPTION
#24 

```
The `pyyaml` version specified in requirements.txt has a security issue - see CVE-2017-18342

This needs to be updated.
```

I tried to check it.