### PR TITLE
To be able to use status name to transition issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.11.0
+
+- Add new ``jira.transition_issue_by_name`` action
+
 ## 0.10.1
 
 - Updated PyYAML to 4.2b4 for CVE-2017-18342

--- a/actions/run.py
+++ b/actions/run.py
@@ -18,8 +18,7 @@ class ActionManager(BaseJiraAction):
         except JIRAError as e:
             return (False, str(e))
         except AttributeError as e:
-            return (False, 'Action "%s" is not implemented.\n%s'
-                    % (action, str(e)))
+            return (False, 'Action "%s" is not implemented' % action)
 
     def transition_name_to_id(self, issue, transition_name):
         transitions = self._client.transitions(issue)

--- a/actions/run.py
+++ b/actions/run.py
@@ -10,8 +10,21 @@ class ActionManager(BaseJiraAction):
 
     def run(self, action, **kwargs):
         try:
+            if action == 'transition_issue_by_name':
+                action = 'transition_issue'
+                kwargs['transition'] = self.transition_name_to_id(**kwargs)
+                del kwargs['transition_name']
             return (True, getattr(self._client, action)(**kwargs))
         except JIRAError as e:
             return (False, str(e))
         except AttributeError as e:
-            return (False, 'Action "%s" is not implemented' % action)
+            return (False, 'Action "%s" is not implemented.\n%s'
+                    % (action, str(e)))
+
+    def transition_name_to_id(self, issue, transition_name):
+        transitions = self._client.transitions(issue)
+        res = list(filter(lambda x: x.get("name") == transition_name,
+                          transitions))
+        if bool(res):
+            return res[0].get("id")
+        return None

--- a/actions/transition_issue.yaml
+++ b/actions/transition_issue.yaml
@@ -11,5 +11,5 @@ parameters:
     required: true
   transition:
     type: string
-    description: Name of transition (e.g. Close, Start Progress, etc).
+    description: ID of transition (e.g. 11, 21, etc).
     required: true

--- a/actions/transition_issue_by_name.yaml
+++ b/actions/transition_issue_by_name.yaml
@@ -1,0 +1,19 @@
+---
+name: transition_issue_by_name
+runner_type: python-script
+description: Do a transition on a JIRA issue / ticket.
+enabled: true
+entry_point: run.py
+parameters:
+  action:
+    default: transition_issue_by_name
+    immutable: true
+    type: string
+  issue:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true
+  transition_name:
+    type: string
+    description: Name of transition (e.g. Close, Start Progress, etc).
+    required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.10.1
+version: 0.11.0
 python_versions:
   - "2"
   - "3"

--- a/tests/test_action_run.py
+++ b/tests/test_action_run.py
@@ -44,3 +44,22 @@ class RunTestCase(JIRABaseActionTestCase):
         (is_success, value) = action.run(action='method')
         self.assertFalse(is_success)
         self.assertEqual(value, "JiraError HTTP error message\n\t")
+
+    @mock.patch('lib.base.JIRA')
+    def test_transition_name_to_id(self, mock_jira):
+        action = self.get_action_instance(self.full_auth_passwd_config)
+
+        def side_effect(*args, **kwargs):
+            return [{'id': '11', 'name': 'Start'},
+                    {'id': '21', 'name': 'Doing'},
+                    {'id': '31', 'name': 'Close'}]
+
+        action._client.transitions.side_effect = side_effect
+
+        kwargs = {'issue': 'ISSUE-XX', 'transition_name': 'Doing'}
+        transition_id = action.transition_name_to_id(**kwargs)
+        self.assertEqual(transition_id, '21')
+
+        kwargs = {'issue': 'ISSUE-XX', 'transition_name': 'Done'}
+        transition_id = action.transition_name_to_id(**kwargs)
+        self.assertEqual(transition_id, None)


### PR DESCRIPTION
The transition_issue action can use only transition id. I want to use the transition name in transition_issue.