### PR TITLE
Added in component and subtask functionality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,6 @@
 ## 0.13.1
 
 - Remove cryptography, pyjwt, pyyaml requirements since we don't use them (PR #41)
->>>>>>> f493c5aa0b491aecf1138dec1f40785aeb4aa4d6
 
 ## 0.13.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.14.0
+
+- Add new ``jira.get_issue_components`` action
+- Add new ``jira.get_issue_subtasks`` action
+
 ## 0.13.0
 
 - Add ``validate`` option to pack config to enable validating credentials

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -8,9 +8,11 @@ __all__ = [
 
 class GetJiraIssueAction(BaseJiraAction):
     def run(self, issue_key, include_comments=False, include_attachments=False,
-            include_customfields=False):
+            include_customfields=False, include_components=False, include_subtasks=False):
         issue = self._client.issue(issue_key)
         result = to_issue_dict(issue=issue, include_comments=include_comments,
                                include_attachments=include_attachments,
-                               include_customfields=include_customfields)
+                               include_customfields=include_customfields,
+                               include_components=include_components,
+                               include_subtasks=include_subtasks)
         return result

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -24,3 +24,14 @@ parameters:
     description: True to include custom fields.
     required: true
     default: false
+  include_components:
+    type: boolean
+    description: True to include custom fields.
+    required: true
+    default: false
+  include_subtasks:
+    type: boolean
+    description: True to include custom fields.
+    required: true
+    default: false
+

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -34,4 +34,3 @@ parameters:
     description: True to include custom fields.
     required: true
     default: false
-

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -64,18 +64,10 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False, incl
             result['attachments'].append(item)
 
     if include_components:
-        result['components'] = []
-
-        for component in issue.fields.components:
-            item = to_component_dict(component)
-            result['components'].append(item)
+        result['components'] = [to_component_dict(c) for c in issue.fields.components]
 
     if include_subtasks:
-        result['subtasks'] = []
-
-        for subtask in issue.fields.subtasks:
-            item = to_subtask_dict(subtask)
-            result['subtasks'].append(item)
+        result['subtasks'] = [to_subtask_dict(s) for s in issue.fields.subtasks]
 
     return result
 
@@ -90,6 +82,7 @@ def to_comment_dict(comment):
     }
     return result
 
+
 def to_component_dict(component):
     """
     :rtype: ``dict``
@@ -100,6 +93,7 @@ def to_component_dict(component):
     }
     return result
 
+
 def to_subtask_dict(subtask):
     """
     :rtype: ``dict``
@@ -107,9 +101,10 @@ def to_subtask_dict(subtask):
     result = {
         'id': subtask.id,
         'key': subtask.key,
-	'summary': subtask.fields.summary
+        'summary': subtask.fields.summary
     }
     return result
+
 
 def to_attachment_dict(attachment):
     """

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -4,7 +4,8 @@ __all__ = [
 ]
 
 
-def to_issue_dict(issue, include_comments=False, include_attachments=False, include_customfields=False, include_components=False, include_subtasks=False):
+def to_issue_dict(issue, include_comments=False, include_attachments=False, 
+                  include_customfields=False, include_components=False, include_subtasks=False):
     """
     :rtype: ``dict``
     """

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -4,7 +4,7 @@ __all__ = [
 ]
 
 
-def to_issue_dict(issue, include_comments=False, include_attachments=False, 
+def to_issue_dict(issue, include_comments=False, include_attachments=False,
                   include_customfields=False, include_components=False, include_subtasks=False):
     """
     :rtype: ``dict``

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -4,8 +4,7 @@ __all__ = [
 ]
 
 
-def to_issue_dict(issue, include_comments=False, include_attachments=False,
-                  include_customfields=False):
+def to_issue_dict(issue, include_comments=False, include_attachments=False, include_customfields=False, include_components=False, include_subtasks=False):
     """
     :rtype: ``dict``
     """
@@ -64,6 +63,20 @@ def to_issue_dict(issue, include_comments=False, include_attachments=False,
             item = to_attachment_dict(attachment)
             result['attachments'].append(item)
 
+    if include_components:
+        result['components'] = []
+
+        for component in issue.fields.components:
+            item = to_component_dict(component)
+            result['components'].append(item)
+
+    if include_subtasks:
+        result['subtasks'] = []
+
+        for subtask in issue.fields.subtasks:
+            item = to_subtask_dict(subtask)
+            result['subtasks'].append(item)
+
     return result
 
 
@@ -77,6 +90,26 @@ def to_comment_dict(comment):
     }
     return result
 
+def to_component_dict(component):
+    """
+    :rtype: ``dict``
+    """
+    result = {
+        'id': component.id,
+        'name': component.name
+    }
+    return result
+
+def to_subtask_dict(subtask):
+    """
+    :rtype: ``dict``
+    """
+    result = {
+        'id': subtask.id,
+        'key': subtask.key,
+	'summary': subtask.fields.summary
+    }
+    return result
 
 def to_attachment_dict(attachment):
     """

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.13.0
+version: 0.14.0
 python_versions:
   - "2"
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.14.0
+version: 0.16.0
 python_versions:
   - "2"
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,11 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-<<<<<<< HEAD
 version: 0.16.0
-=======
-version: 0.15.0
->>>>>>> f493c5aa0b491aecf1138dec1f40785aeb4aa4d6
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
I required the ability to query both components and subtasks when manipulating Jira issue webhooks and noticed that there wasn't any fields defined in this pack for them. I have slotted them in as optionally requested values.

They don't have the full functionality like comments do where they can be inserted as well as queried, as the jira-python library that this pack is built on does not have that functionality.