### PR TITLE
Remove unused dependencies cryptography, pyjwt, and pyyaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.13.1
+
+- Remove cryptography, pyjwt, pyyaml requirements since we don't use them (PR #41)
+
 ## 0.13.0
 
 - Add ``validate`` option to pack config to enable validating credentials

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.13.0
+version: 0.13.1
 python_versions:
   - "2"
   - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 jira==2.0.0
-pyyaml==4.2b4
-cryptography==2.4.1
-pyjwt==1.6.4


### PR DESCRIPTION
Remove unused dependencies since they aren't important anywhere.

* [`pyyaml` was originally used years and years ago](https://github.com/StackStorm-Exchange/stackstorm-jira/commit/a60255b2eababac08303177c3d1795e3ec373102) when packs had to [manually read their own configuration files](https://github.com/StackStorm-Exchange/stackstorm-jira/blob/a60255b2eababac08303177c3d1795e3ec373102/actions/create_issue.py#L10)
* [`cryptography` snuck in somehow](https://github.com/StackStorm-Exchange/stackstorm-jira/commit/9bb998af539f60b1ed8c5e89494e33d696f03e83)
* [`pyjwt` snuck in somehow](https://github.com/StackStorm-Exchange/stackstorm-jira/commit/0a6e1b1dd154fdb8ba688123a1df58f9c2905cd1)

The pyyaml dependency in particular has even [caused us unnecessary work](#26)!