### PR TITLE
Support cookie-based authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.14.0
+
+- Support cookie-based authentication (PR #42)
+
 ## 0.13.1
 
 - Remove cryptography, pyjwt, pyyaml requirements since we don't use them (PR #41)

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -41,9 +41,13 @@ class BaseJiraAction(Action):
             client = JIRA(options=options, basic_auth=basic_creds,
                           validate=config.get('validate', False))
 
+        elif auth_method == 'cookie':
+            basic_creds = (config['username'], config['password'])
+            client = JIRA(options=options, auth=basic_creds)
+
         else:
-            msg = ('You must set auth_method to either "oauth"',
-                   'or "basic" your jira.yaml config file.')
+            msg = ('You must set auth_method to either "oauth", ',
+                   '"basic", or "cookie" in your Jira pack config file.')
             raise Exception(msg)
 
         return client

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -17,13 +17,14 @@
     enum:
       - oauth
       - basic
+      - cookie
   username:
-    description: "Username if using the basic auth_method"
+    description: "Username if using the basic or cookie auth_method"
     type: "string"
     secret: false
     required: false
   password:
-    description: "Password if using the basic auth_method"
+    description: "Password if using the basic or cookie auth_method"
     type: "string"
     secret: true
     required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 0.13.1
+version: 0.14.0
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Add support for cookie-based authentication, since the [upstream Jira documentation](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-cookie-based-authentication/) recommends that for non-cloud Jira installations.