### PR TITLE
New bulk_link_issue action to cross-link many JIRA issues to one

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 2.1.0
 
-- Add new ``jira.bulk_link_issues`` action
+- Add new ``jira.bulk_link_issues`` action (PR #50)
 
 ## 2.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.1.0
+
+- Add new ``jira.bulk_link_issues`` action
+
 ## 2.0.0
 
 - [#48](https://github.com/StackStorm-Exchange/stackstorm-jira/issues/48) Update `jira==3.2.0`

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The sensor monitors for new tickets and sends a trigger into the system whenever
 * ``assign_issue`` - Assigning an issue to a user.
 * ``attach_file_to_issue`` - Attach a file to JIRA issue / ticket.
 * ``attach_files_to_issue`` - Attach multiple files to JIRA issue / ticket.
+* ``bulk_link_issue`` - Link many JIRA issues to another JIRA issue.
 * ``comment_issue`` - Comment on a JIRA issue / ticket.
 * ``create_issue`` - Create a new JIRA issue / ticket.
 * ``get_issue`` - Retrieve information about a particular JIRA issue.

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -1,0 +1,20 @@
+from lib.base import BaseJiraAction
+
+__all__ = [
+    'BulkLinkJiraIssueAction'
+]
+
+
+class BulkLinkJiraIssueAction(BaseJiraAction):
+
+    def run(self, issue_key_list=None, target_issue=None, direction=None, link_type=None):
+        if direction == 'outward':
+            inward_issue_key = target_issue  
+            for outward_issue_key in issue_key_list:
+                issue = self._client.create_issue_link(link_type, inward_issue_key, outward_issue_key)
+        if direction == 'inward':
+            outward_issue_key = target_issue  
+            for inward_issue_key in issue_key_list:
+                issue = self._client.create_issue_link(link_type, inward_issue_key, outward_issue_key)
+
+        return issue

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -9,12 +9,12 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
 
     def run(self, issue_key_list=None, target_issue=None, direction=None, link_type=None):
         if direction == 'outward':
-            inward_issue_key = target_issue 
+            inward_issue_key = target_issue
             for outward_issue_key in issue_key_list:
-                issue = self._client.create_issue_link(link_type, inward_issue_key, 
+                issue = self._client.create_issue_link(link_type, inward_issue_key,
                                                        outward_issue_key)
         if direction == 'inward':
-            outward_issue_key = target_issue 
+            outward_issue_key = target_issue
             for inward_issue_key in issue_key_list:
                 issue = self._client.create_issue_link(link_type, inward_issue_key,
                                                        outward_issue_key)

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -9,12 +9,13 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
 
     def run(self, issue_key_list=None, target_issue=None, direction=None, link_type=None):
         if direction == 'outward':
-            inward_issue_key = target_issue  
+            inward_issue_key = target_issue 
             for outward_issue_key in issue_key_list:
-                issue = self._client.create_issue_link(link_type, inward_issue_key, outward_issue_key)
+                issue = self._client.create_issue_link(link_type, inward_issue_key, 
+                                                       outward_issue_key)
         if direction == 'inward':
-            outward_issue_key = target_issue  
+            outward_issue_key = target_issue 
             for inward_issue_key in issue_key_list:
-                issue = self._client.create_issue_link(link_type, inward_issue_key, outward_issue_key)
-
+                issue = self._client.create_issue_link(link_type, inward_issue_key,
+                                                       outward_issue_key)
         return issue

--- a/actions/bulk_link_issue.yaml
+++ b/actions/bulk_link_issue.yaml
@@ -1,0 +1,27 @@
+---
+name: bulk_link_issue
+runner_type: python-script
+description: "Receives a list of Jiras ticket issue keys and a target Jira ticket, lazy link the list of Jira tickets to the parent"
+enabled: true
+entry_point: bulk_link_issue.py
+parameters:
+  issue_key_list:
+    required: true
+    type: array
+  target_issue:
+    type: string
+    description: Target issue to link the list of tickets to/from
+    required: true
+  direction:
+    description: Direction for link relation. Outward links 1:many (one ticket relates to many children). Inward links many:1 (many tickets relate to one child).
+    default: outward
+    type: string
+    enum:
+    - outward
+    - inward
+    required: true
+  link_type:
+    type: string
+    description: The type of link to create.
+    required: true
+    default: relates

--- a/actions/bulk_link_issue.yaml
+++ b/actions/bulk_link_issue.yaml
@@ -6,20 +6,21 @@ enabled: true
 entry_point: bulk_link_issue.py
 parameters:
   issue_key_list:
-    required: true
     type: array
+    description: List of tickets to link to/from the target issue.
+    required: true
   target_issue:
     type: string
-    description: Target issue to link the list of tickets to/from
+    description: Target issue to link the list of tickets to/from.
     required: true
   direction:
-    description: Direction for link relation. Outward links 1:many (one ticket relates to many children). Inward links many:1 (many tickets relate to one child).
-    default: outward
     type: string
+    description: Direction for link relation. Outward links 1:many (one ticket relates to many children). Inward links many:1 (many tickets relate to one child).
     enum:
     - outward
     - inward
     required: true
+    default: outward
   link_type:
     type: string
     description: The type of link to create.

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 2.0.0
+version: 2.1.0
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
Adding in a small feature extension on the link_issue feature.

We were running into processing thread limits in workflows which simply used a with: items loop against the existing link_issue action. 

For our data we would receive a payload with anywhere from 10-25 issues and a list of links for each of those which could have anywhere from 1-100+ items.

Even after trying to adjust workflow/action threads in st2.config we were seeing issues with processing times. Condensing our loop into a single action has helped reduce some of our outlier processing times when dealing with large numbers of links.