### PR TITLE
Multithreading in linking multiple issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.4.3
+
+- Added multithreading in linking multiple issue functionality to speed up the response.
+
 ## 2.4.2
 
 - Update `formatters.py` to include `priority` field

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 2.4.3
+## 2.5.0
 
 - Added multithreading in linking multiple issue functionality to speed up the response.
 

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -13,6 +13,8 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
         link_type=None,
     ):
         with semaphore:
+            outward_issue_key = ""
+            inward_issue_key = ""
             if direction == "outward":
                 outward_issue_key = issue_key
                 inward_issue_key = target_issue
@@ -26,7 +28,7 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
                 response = self._client.create_issue_link(
                     link_type, inward_issue_key, outward_issue_key
                 )
-            response_output = {"issue": target_issue, "response": response}
+            response_output = {"inward_issue": inward_issue_key, "outward_issue": outward_issue_key, "response": response}
         print(response_output)
 
     def run(self, issue_key_list, target_issue, direction, link_type):

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -1,21 +1,29 @@
+import threading
+from threading import Semaphore
 from lib.base import BaseJiraAction
 
-__all__ = [
-    'BulkLinkJiraIssueAction'
-]
-
-
 class BulkLinkJiraIssueAction(BaseJiraAction):
+    def link_issues(self,semaphore, issue_key=None, target_issue=None, direction=None, link_type=None):
+        with semaphore:
+            if direction == 'outward':
+                outward_issue_key = issue_key
+                inward_issue_key = target_issue
+                response = self._client.create_issue_link(link_type, inward_issue_key,outward_issue_key)
 
-    def run(self, issue_key_list=None, target_issue=None, direction=None, link_type=None):
-        if direction == 'outward':
-            inward_issue_key = target_issue
-            for outward_issue_key in issue_key_list:
-                issue = self._client.create_issue_link(link_type, inward_issue_key,
-                                                       outward_issue_key)
-        if direction == 'inward':
-            outward_issue_key = target_issue
-            for inward_issue_key in issue_key_list:
-                issue = self._client.create_issue_link(link_type, inward_issue_key,
-                                                       outward_issue_key)
-        return issue
+            if direction == 'inward':
+                inward_issue_key = issue_key
+                outward_issue_key = target_issue
+                response = self._client.create_issue_link(link_type, inward_issue_key,outward_issue_key)
+            response_output = {"issue": target_issue, "response": response}
+        print(response_output)
+
+    def run(self, issue_key_list, target_issue, direction, link_type):
+        threads = list()
+        semaphore = Semaphore(10)
+        for issue_key in issue_key_list:
+            x = threading.Thread(target=self.link_issues, args=(semaphore, issue_key, target_issue, direction, link_type))
+            threads.append(x)
+            x.start()
+
+        for thread in threads:
+                thread.join()

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -2,18 +2,30 @@ import threading
 from threading import Semaphore
 from lib.base import BaseJiraAction
 
+
 class BulkLinkJiraIssueAction(BaseJiraAction):
-    def link_issues(self,semaphore, issue_key=None, target_issue=None, direction=None, link_type=None):
+    def link_issues(
+        self,
+        semaphore,
+        issue_key=None,
+        target_issue=None,
+        direction=None,
+        link_type=None,
+    ):
         with semaphore:
-            if direction == 'outward':
+            if direction == "outward":
                 outward_issue_key = issue_key
                 inward_issue_key = target_issue
-                response = self._client.create_issue_link(link_type, inward_issue_key,outward_issue_key)
+                response = self._client.create_issue_link(
+                    link_type, inward_issue_key, outward_issue_key
+                )
 
-            if direction == 'inward':
+            if direction == "inward":
                 inward_issue_key = issue_key
                 outward_issue_key = target_issue
-                response = self._client.create_issue_link(link_type, inward_issue_key,outward_issue_key)
+                response = self._client.create_issue_link(
+                    link_type, inward_issue_key, outward_issue_key
+                )
             response_output = {"issue": target_issue, "response": response}
         print(response_output)
 
@@ -21,9 +33,12 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
         threads = list()
         semaphore = Semaphore(10)
         for issue_key in issue_key_list:
-            x = threading.Thread(target=self.link_issues, args=(semaphore, issue_key, target_issue, direction, link_type))
+            x = threading.Thread(
+                target=self.link_issues,
+                args=(semaphore, issue_key, target_issue, direction, link_type),
+            )
             threads.append(x)
             x.start()
 
         for thread in threads:
-                thread.join()
+            thread.join()

--- a/actions/bulk_link_issue.py
+++ b/actions/bulk_link_issue.py
@@ -28,7 +28,11 @@ class BulkLinkJiraIssueAction(BaseJiraAction):
                 response = self._client.create_issue_link(
                     link_type, inward_issue_key, outward_issue_key
                 )
-            response_output = {"inward_issue": inward_issue_key, "outward_issue": outward_issue_key, "response": response}
+            response_output = {
+                "inward_issue": inward_issue_key,
+                "outward_issue": outward_issue_key,
+                "response": response,
+            }
         print(response_output)
 
     def run(self, issue_key_list, target_issue, direction, link_type):

--- a/actions/bulk_link_issue.yaml
+++ b/actions/bulk_link_issue.yaml
@@ -25,4 +25,4 @@ parameters:
     type: string
     description: The type of link to create.
     required: true
-    default: relates
+    default: relates to

--- a/actions/link_issue.yaml
+++ b/actions/link_issue.yaml
@@ -17,3 +17,4 @@ parameters:
     type: string
     description: The type of link to create.
     required: true
+    default: relates to

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 2.4.3
+version: 2.5.0
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 2.4.2
+version: 2.4.3
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
- Changed the linking of multiple issue functianlity with usage of mulithreading to speed up the results.
- As per feedback to previous PR which was closed accidentaly, the default value of link_type is set to "relates to" instaed "relates"
- For print, instead of printing just response, response is paired along with its issue_id for easy debugging.