### PR TITLE
Create `update_priority` action to change issue's priority

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.4.3
+
+- Add `update_priority` action for changing an issue's priority
+  
 ## 2.4.2
 
 - Update `formatters.py` to include `priority` field

--- a/actions/update_priority.py
+++ b/actions/update_priority.py
@@ -1,0 +1,13 @@
+from lib.base import BaseJiraAction
+from lib.formatters import to_issue_dict
+
+__all__ = [
+    'UpdateFieldValue'
+]
+
+
+class UpdatePriority(BaseJiraAction):
+    def run(self, issue_key, new_priority, notify):
+        issue = self._client.issue(issue_key)
+        issue.update(fields={priority: new_priority}, notify=notify)
+        return to_issue_dict(issue)

--- a/actions/update_priority.py
+++ b/actions/update_priority.py
@@ -2,9 +2,8 @@ from lib.base import BaseJiraAction
 from lib.formatters import to_issue_dict
 
 __all__ = [
-    'UpdateFieldValue'
+    'UpdatePriority'
 ]
-
 
 class UpdatePriority(BaseJiraAction):
     def run(self, issue_key, new_priority, notify):

--- a/actions/update_priority.py
+++ b/actions/update_priority.py
@@ -5,6 +5,7 @@ __all__ = [
     'UpdatePriority'
 ]
 
+
 class UpdatePriority(BaseJiraAction):
     def run(self, issue_key, new_priority, notify):
         issue = self._client.issue(issue_key)

--- a/actions/update_priority.py
+++ b/actions/update_priority.py
@@ -8,5 +8,5 @@ __all__ = [
 class UpdatePriority(BaseJiraAction):
     def run(self, issue_key, new_priority, notify):
         issue = self._client.issue(issue_key)
-        issue.update(fields={priority: new_priority}, notify=notify)
+        issue.update(fields={"priority": new_priority}, notify=notify)
         return to_issue_dict(issue)

--- a/actions/update_priority.yaml
+++ b/actions/update_priority.yaml
@@ -9,7 +9,7 @@ parameters:
     type: string
     description: Issue key (e.g. PROJECT-1000).
     required: true
-  priority:
+  new_priority:
     type: object
     description: New priority object (e.g { 'name':'High'} or { 'id':'2'} ).
     required: true

--- a/actions/update_priority.yaml
+++ b/actions/update_priority.yaml
@@ -13,3 +13,8 @@ parameters:
     type: object
     description: New priority object (e.g { 'name':'High'} or { 'id':'2'} ).
     required: true
+  notify:
+    type: boolean
+    description: jira will send notifications (default is true)
+    default: true
+    required: false

--- a/actions/update_priority.yaml
+++ b/actions/update_priority.yaml
@@ -1,0 +1,15 @@
+---
+name: update_priority
+runner_type: python-script
+description: Update the priority or a JIRA issue.
+enabled: true
+entry_point: update_priority.py
+parameters:
+  issue_key:
+    type: string
+    description: Issue key (e.g. PROJECT-1000).
+    required: true
+  priority:
+    type: object
+    description: New priority object (e.g { 'name':'High'} or { 'id':'2'} ).
+    required: true

--- a/actions/update_priority.yaml
+++ b/actions/update_priority.yaml
@@ -11,7 +11,7 @@ parameters:
     required: true
   new_priority:
     type: object
-    description: New priority object (e.g { 'name':'High'} or { 'id':'2'} ).
+    description: New priority object (e.g { "name":"High"} or { "id":"2"} ).
     required: true
   notify:
     type: boolean

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 2.4.2
+version: 2.4.3
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
This PR is for the introduction of a new action, `update_priority`, as it could not be set using the `update_field_value`: Jira requires the priority to be an object rather than a string.

More information on this here:
https://github.com/StackStorm-Exchange/stackstorm-jira/issues/65
