### PR TITLE
Add `on: workflow_dispatch` #74

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -5,6 +5,7 @@ on:
   schedule:
     # NOTE: We run this weekly at 1 am UTC on every Saturday
     - cron:  '0 1 * * 6'
+  workflow_dispatch:
 
 jobs:
   # This is mirrored in the release workflow.


### PR DESCRIPTION
This should allow folks with the appropriate permissions to re-run/run test action executions.

#74 