### PR TITLE
Fix `update_dashboard` #76: Correct Payload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.0.1
+
+- Fixed bug with `update_dashboard` action sending the wrong payload.
+
 ## 3.0.0
 
 - Drop support for `python 3.6`

--- a/actions/update_dashboard.py
+++ b/actions/update_dashboard.py
@@ -17,8 +17,8 @@ class UpdateJiraDashboardAction(BaseJiraAction):
             {
                 "name": name,
                 "description": description,
-                "edit_permissions": edit_permissions,
-                "share_permissions": share_permissions,
+                "editPermissions": edit_permissions,
+                "sharePermissions": share_permissions,
             }
         )
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.0.0
+version: 3.0.1
 python_versions:
   - "3"
 author: StackStorm, Inc.


### PR DESCRIPTION
Turns out during my testing, I forgot to have a permutation where I updated the permissions of a dashboard. Discovered the payload is malformed because of a lack of post-processing in the `jira` lib (this is as intended). This PR fixes the issue.

* Update keys in payload dict for `update_dashboard` action from `edit_permissions/share_permissions` to
`editPermissions/sharePermissions` to make the `jira` API happy.