### PR TITLE
Adding ability to sanitize output for jinja templating

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 # Change Log
 
 ## 3.1.0
-- Add new feature to ``jira.get_issue`` to allow for stripping of Jinja templating artifacts from resulting output. (Removes instances of {{ }} from results.).
+- Add new feature to ``jira.get_issue`` to allow for stripping of Jinja templating artifacts from resulting output. (Removes instances of {{ }} from results.)
+
+  Example: You pull a jira with ``code`` block in a comment or the description. To the API that shows up as {{ code }} which is jinja Templating and will cause 
+  issues when trying to use that outpu anywhere else in a workflow as it cannot find the `code` variable in the context.
+  
 
 ## 3.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 - Add new feature to ``jira.get_issue`` to allow for stripping of Jinja templating artifacts from resulting output. (Removes instances of {{ }} from results.)
 
   Example: You pull a jira with ``code`` block in a comment or the description. To the API that shows up as {{ code }} which is jinja Templating and will cause 
-  issues when trying to use that outpu anywhere else in a workflow as it cannot find the `code` variable in the context.
+  issues when trying to use that output anywhere else in a workflow as it cannot find the `code` variable in the context.
   
 
 ## 3.0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## 3.0.2
-- Add new feature to get_issue to allow for stripping of Jinja templating artifacts.
+## 3.1.0
+- Add new feature to ``jira.get_issue`` to allow for stripping of Jinja templating artifacts from resulting output. (Removes instances of {{ }} from results.).
 
 ## 3.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.0.2
+- Add new feature to get_issue to allow for stripping of Jinja templating artifacts.
+
 ## 3.0.1
 
 - Fixed bug with `update_dashboard` action sending the wrong payload.

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -29,4 +29,3 @@ class GetJiraIssueAction(BaseJiraAction):
                 return data
 
         return strip_braces(result) if sanitize_formatting else result
-    

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -9,7 +9,7 @@ __all__ = [
 class GetJiraIssueAction(BaseJiraAction):
     def run(self, issue_key, include_comments=False, include_attachments=False,
             include_customfields=False, include_components=False, include_subtasks=False,
-            include_links=False):
+            include_links=False, sanitize_formatting=False):
         issue = self._client.issue(issue_key)
         result = to_issue_dict(issue=issue, include_comments=include_comments,
                                include_attachments=include_attachments,
@@ -17,4 +17,19 @@ class GetJiraIssueAction(BaseJiraAction):
                                include_components=include_components,
                                include_subtasks=include_subtasks,
                                include_links=include_links)
-        return result
+
+        def strip_braces(data):
+            if isinstance(data, dict):
+                return {k: strip_braces(v) for k, v in data.items()}
+            elif isinstance(data, list):
+                return [strip_braces(element) for element in data]
+            elif isinstance(data, str):
+                return data.replace("{{", "").replace("}}", "")
+            else:
+                return data
+
+        cleaned_issue_dict = strip_braces(issue_dict)
+        if sanitize_formatting:
+            return strip_braces(result)
+        else:
+            return result

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -29,3 +29,4 @@ class GetJiraIssueAction(BaseJiraAction):
                 return data
 
         return strip_braces(result) if sanitize_formatting else result
+    

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -28,7 +28,4 @@ class GetJiraIssueAction(BaseJiraAction):
             else:
                 return data
 
-        if sanitize_formatting:
-            return strip_braces(result)
-        else:
-            return result
+        return strip_braces(result) if sanitize_formatting else result

--- a/actions/get_issue.py
+++ b/actions/get_issue.py
@@ -28,7 +28,6 @@ class GetJiraIssueAction(BaseJiraAction):
             else:
                 return data
 
-        cleaned_issue_dict = strip_braces(issue_dict)
         if sanitize_formatting:
             return strip_braces(result)
         else:

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -39,3 +39,8 @@ parameters:
     description: True to include linked issues.
     required: true
     default: false
+  sanitize_formatting:
+    type: boolean
+    description: True to remove jinja template artifacts.
+    required: true
+    default: false

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -41,6 +41,6 @@ parameters:
     default: false
   sanitize_formatting:
     type: boolean
-    description: True to remove jinja template artifacts.
+    description: When set to true removes jinja template artifacts.
     required: true
     default: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.0.1
+version: 3.0.2
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.0.2
+version: 3.1.0
 python_versions:
   - "3"
 author: StackStorm, Inc.


### PR DESCRIPTION
What am I trying to do? 
I am trying to sanitize output of jira, at all levels of any jinja templating things that would be markdown artifacts from getting jira data from the API so that it does not cause issues after you get it and try to use it as a var in a workflow due to those artifacts existing and causing stackstorm to think it is missing a variable.

I went for minimal touch instead of making it default, it is leaving it how it was unless you set it to true. Then it will iterate through all levels of the data to remove any of the jinja templating which from what I have found is mainly the `{{` and `}}` .