### PR TITLE
Allow users to update other fields during `transition`.

### DIFF
--- a/actions/transition_issue.py
+++ b/actions/transition_issue.py
@@ -7,6 +7,6 @@ __all__ = [
 
 class TransitionJiraIssueAction(BaseJiraAction):
 
-    def run(self, issue_key, transition):
-        result = self._client.transition_issue(issue_key, transition)
+    def run(self, issue_key, transition, fields):
+        result = self._client.transition_issue(issue_key, transition, fields=fields)
         return result

--- a/actions/transition_issue.yaml
+++ b/actions/transition_issue.yaml
@@ -13,3 +13,9 @@ parameters:
     type: string
     description: ID of transition (e.g. 11, 21, etc).
     required: true
+  fields:
+    type: object
+    description: >-
+      Fields to update on the issue. For example to set resolution to "Fixed"
+      {"resolution": {"name": "Fixed"}}.
+    required: false


### PR DESCRIPTION
We have need of the ability to set the resolution of a ticket when we are transitioning it to a `Done` state. This should do the trick. For reference:

https://github.com/pycontribs/jira/blob/3a630c5f1c771fb27b407860d684da879d14e622/jira/client.py#L2557