### PR TITLE
Allow users to update other fields during transition.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
 # Change Log
 
-## 3.1.0
+## 3.2.0
 - Add new feature to ``jira.get_issue`` to allow for stripping of Jinja templating artifacts from resulting output. (Removes instances of {{ }} from results.)
 
-  Example: You pull a jira with ``code`` block in a comment or the description. To the API that shows up as {{ code }} which is jinja Templating and will cause 
+  Example: You pull a jira with ``code`` block in a comment or the description. To the API that shows up as {{ code }} which is jinja Templating and will cause
   issues when trying to use that output anywhere else in a workflow as it cannot find the `code` variable in the context.
-  
+
 
 ## 3.0.1
 

--- a/actions/transition_issue.py
+++ b/actions/transition_issue.py
@@ -1,12 +1,9 @@
 from lib.base import BaseJiraAction
 
-__all__ = [
-    'TransitionJiraIssueAction'
-]
+__all__ = ["TransitionJiraIssueAction"]
 
 
 class TransitionJiraIssueAction(BaseJiraAction):
-
-    def run(self, issue_key, transition):
-        result = self._client.transition_issue(issue_key, transition)
+    def run(self, issue_key, transition, fields):
+        result = self._client.transition_issue(issue_key, transition, fields=fields)
         return result

--- a/actions/transition_issue.yaml
+++ b/actions/transition_issue.yaml
@@ -13,3 +13,9 @@ parameters:
     type: string
     description: ID of transition (e.g. 11, 21, etc).
     required: true
+  fields:
+    type: object
+    description: >-
+      Fields to update on the issue. For example to set resolution to "Fixed"
+      {"resolution": {"name": "Fixed"}}.
+    required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.1.0
+version: 3.2.0
 python_versions:
   - "3"
 author: StackStorm, Inc.


### PR DESCRIPTION
We have need of the ability to set the resolution of a ticket when we are transitioning it to a Done state. This should do the trick. For reference:

https://github.com/pycontribs/jira/blob/3a630c5f1c771fb27b407860d684da879d14e622/jira/client.py#L2557

Here is an example run - slightly redacted:

```yaml
id: 67c0f173a15f4adcd5685efa
action.ref: jira.transition_issue
context.user: st2admin
parameters:
  fields:
    resolution:
      name: Done
  issue_key: JIRA-1234
  log_level: DEBUG
  transition: Done
status: succeeded (2s elapsed)
start_timestamp: Thu, 27 Feb 2025 23:12:51 UTC
end_timestamp: Thu, 27 Feb 2025 23:12:53 UTC
log:
  - status: requested
    timestamp: '2025-02-27T23:12:51.179000Z'
  - status: scheduled
    timestamp: '2025-02-27T23:12:51.274000Z'
  - status: running
    timestamp: '2025-02-27T23:12:51.312000Z'
  - status: succeeded
    timestamp: '2025-02-27T23:12:53.269000Z'
result:
  exit_code: 0
  result: {}
  stderr: ''
  stdout: ''
```

And the result of `get_issue`:
```yaml
id: 67c0f205a15f4adcd5685efc
action.ref: jira.get_issue
context.user: st2admin
parameters:
  issue_key: IRA-15117
status: succeeded
start_timestamp: Thu, 27 Feb 2025 23:15:17 UTC
end_timestamp: Thu, 27 Feb 2025 23:15:19 UTC
result:
  exit_code: 0
  result:
    assignee: null
    created_at: 2025-02-20T15:48:34.434-0500
    id: '1178301'
    key: JIRA-15117
    priority: Unprioritized
    reporter: Some Guy
    resolution: Done
    resolved_at: 2025-02-27T18:12:52.879-0500
  stderr: ''
  stdout: ''
```