### PR TITLE
Update JIRA sensor to use patched search 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.2.3
+- Addresses [#87](https://github.com/StackStorm-Exchange/stackstorm-jira/issues/87) JIRA sensor failure due to [deprecation of /v2/search endpoint](https://developer.atlassian.com/changelog/#CHANGE-2046)
+
 ## 3.2.2
 - Addresses [#87](https://github.com/StackStorm-Exchange/stackstorm-jira/issues/87) search failure due to [deprecation of /v2/search endpoint](https://developer.atlassian.com/changelog/#CHANGE-2046)
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - issues
   - ticket management
   - project management
-version: 3.2.2
+version: 3.2.3
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/sensors/jira_sensor_for_apiv2.py
+++ b/sensors/jira_sensor_for_apiv2.py
@@ -2,7 +2,7 @@
 import os
 import base64
 
-from jira.client import JIRA
+from patched_search import JIRA
 
 from st2reactor.sensor.base import PollingSensor
 


### PR DESCRIPTION
To workarround the issue with JIRA deprecated API v2, updating impacted JIRA sensor code as well to use patched_search created in PR https://github.com/StackStorm-Exchange/stackstorm-jira/pull/88